### PR TITLE
Support P2SH-P2WPKH and P2WPKH in snap

### DIFF
--- a/packages/example/src/components/Account/Main.tsx
+++ b/packages/example/src/components/Account/Main.tsx
@@ -51,7 +51,7 @@ export const bitcoinUnit = {
 }
 
 const Main = observer(({balance, receiveAddress, utxos, sendInfo}: MainProps) => {
-  const { global: { network }} = useKeystoneStore();
+  const { global: { network, scriptType }} = useKeystoneStore();
   const [showReceiveModal, setShowReceiveModal] = useState<boolean>(false);
   const [showDetailModal, setShowDetailModal] = useState<boolean>(false);
   const [currencyUnit, setCurrencyUnit] = useState<string>(bitcoinUnit[network].BTC);
@@ -125,7 +125,7 @@ const Main = observer(({balance, receiveAddress, utxos, sendInfo}: MainProps) =>
 
       <ActionContainer>
         <ActionContainerItem>
-          <SendModal network={network} utxos={utxos} sendInfo={sendInfo} />
+          <SendModal network={network} scriptType={scriptType} utxos={utxos} sendInfo={sendInfo} />
           <ActionLabel>send</ActionLabel>
         </ActionContainerItem>
         <ActionContainerItem onClick={onReceive}>

--- a/packages/example/src/components/Connect/RevealXpub.tsx
+++ b/packages/example/src/components/Connect/RevealXpub.tsx
@@ -13,12 +13,12 @@ export interface RevealXpubProps {
 }
 
 const RevealXpub = ({open, onRevealed}: RevealXpubProps) => {
-  const { global: { network, updateBip44Xpub }} = useKeystoneStore();
+  const { global: { network, scriptType, updateBip44Xpub }} = useKeystoneStore();
   const [isRevealing, setIsRevealing] = useState<boolean>(false);
 
   const getXpub = useCallback(async () => {
     setIsRevealing(true);
-    getExtendedPublicKey(network, (xpub: string) => {
+    getExtendedPublicKey(network, scriptType, ({xpub, mfp}) => {
       if (xpub) {
         updateBip44Xpub(xpub);
         updateStoredXpub(xpub, network);

--- a/packages/example/src/components/SendModal/index.tsx
+++ b/packages/example/src/components/SendModal/index.tsx
@@ -4,7 +4,7 @@ import React, { FunctionComponent, useEffect, useMemo } from 'react';
 import './index.css';
 import { observer } from 'mobx-react-lite';
 import SendViewModel from './model';
-import { BitcoinNetwork, Utxo } from '../../interface';
+import { BitcoinNetwork, BitcoinScriptType, Utxo } from '../../interface';
 import { SendInfo } from '../../lib';
 import Initial from './Initial';
 import Result from './Result';
@@ -15,6 +15,7 @@ import { ActionButton } from "./styles";
 type ContainerProps = {
   utxos: Utxo[];
   network: BitcoinNetwork;
+  scriptType: BitcoinScriptType;
   sendInfo?: SendInfo;
 };
 
@@ -26,6 +27,7 @@ const SendContainer: FunctionComponent<ContainerProps> = props => {
       props.utxos,
       feeRate,
       props.network,
+      props.scriptType,
       props.sendInfo,
     );
   }, []);

--- a/packages/example/src/components/SendModal/model.ts
+++ b/packages/example/src/components/SendModal/model.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'bignumber.js';
 import { makeAutoObservable, reaction } from 'mobx';
-import { BitcoinNetwork, Utxo } from '../../interface';
+import { BitcoinNetwork, BitcoinScriptType, Utxo } from '../../interface';
 import { genreatePSBT, selectUtxos, SendInfo, sendTx } from '../../lib';
 import validate, { Network } from 'bitcoin-address-validation';
 import { signPsbt } from '../../lib/snap';
@@ -50,6 +50,7 @@ class SendViewModel {
     private utxos: Utxo[],
     private feeRate: number,
     public network: BitcoinNetwork,
+    private scriptType: BitcoinScriptType,
     private sendInfo?: SendInfo,
   ) {
     makeAutoObservable(this);
@@ -224,7 +225,7 @@ class SendViewModel {
           this.selectedResult.inputs,
           this.selectedResult.outputs,
         );
-        const { txId, txHex } = await signPsbt(psbt.toBase64(), this.network);
+        const { txId, txHex } = await signPsbt(psbt.toBase64(), this.network, this.scriptType);
         this.txId = txId;
         trackSendSign(this.network)
 

--- a/packages/example/src/interface.ts
+++ b/packages/example/src/interface.ts
@@ -4,9 +4,9 @@ export enum BitcoinNetwork {
 }
 
 export enum BitcoinScriptType {
-  P2PKH,
-  P2SH,
-  P2WPKH,
+  P2PKH = "P2PKH",
+  P2SH_P2WPKH = "P2SH-P2WPKH",
+  P2WPKH = "P2WPKH",
 }
 
 export type Utxo = {

--- a/packages/example/src/lib/explorer.ts
+++ b/packages/example/src/lib/explorer.ts
@@ -132,7 +132,7 @@ export class BlockChair implements Exloper {
     if (network === BitcoinNetwork.Test) {
       if (scriptType === BitcoinScriptType.P2PKH) {
         return this.transferNode(extendedPubKey, 'xpub', config);
-      } else if (scriptType === BitcoinScriptType.P2SH) {
+      } else if (scriptType === BitcoinScriptType.P2SH_P2WPKH) {
         return this.transferNode(extendedPubKey, 'ypub', config);
       } else {
         return this.transferNode(extendedPubKey, 'zpub', config);

--- a/packages/example/src/lib/index.ts
+++ b/packages/example/src/lib/index.ts
@@ -37,12 +37,12 @@ export const networkAndScriptMap: networkAndScriptType = {
   },
   ypub: {
     network: BitcoinNetwork.Main,
-    scriptType: BitcoinScriptType.P2SH,
+    scriptType: BitcoinScriptType.P2SH_P2WPKH,
     config: { private: 0x049d7878, public: 0x049d7cb2 },
   },
   yprv: {
     network: BitcoinNetwork.Main,
-    scriptType: BitcoinScriptType.P2SH,
+    scriptType: BitcoinScriptType.P2SH_P2WPKH,
     config: { private: 0x049d7878, public: 0x049d7cb2 },
   },
   zpub: {
@@ -67,12 +67,12 @@ export const networkAndScriptMap: networkAndScriptType = {
   },
   upub: {
     network: BitcoinNetwork.Test,
-    scriptType: BitcoinScriptType.P2SH,
+    scriptType: BitcoinScriptType.P2SH_P2WPKH,
     config: { private: 0x044a4e28, public: 0x044a5262 },
   },
   uprv: {
     network: BitcoinNetwork.Test,
-    scriptType: BitcoinScriptType.P2SH,
+    scriptType: BitcoinScriptType.P2SH_P2WPKH,
     config: { private: 0x044a4e28, public: 0x044a5262 },
   },
   vpub: {
@@ -115,7 +115,7 @@ const caculateBitcoinAddress = (
       network: networkConfig,
     });
     return address;
-  } else if (scriptType === BitcoinScriptType.P2SH) {
+  } else if (scriptType === BitcoinScriptType.P2SH_P2WPKH) {
     const { address } = payments.p2sh({
       redeem: payments.p2wpkh({
         pubkey: pubKey,

--- a/packages/example/src/lib/snap.ts
+++ b/packages/example/src/lib/snap.ts
@@ -1,5 +1,6 @@
 import { MetaMaskInpageProvider } from '@metamask/providers';
 import { BitcoinNetwork, BitcoinScriptType } from '../interface';
+
 declare global {
   interface Window {
     ethereum: MetaMaskInpageProvider;
@@ -31,19 +32,31 @@ export async function connect(cb: (connected: boolean) => void) {
 
 /**
  *
- * get the extened publicKey from btcsnap
+ * get the extended publicKey from btcsnap
  *
  * @param network
+ * @param scriptType
+ * @param cb?
  * @returns
  */
 
+interface ExtendedPublicKey {
+  xpub: string;
+  mfp: string;
+}
+
 export async function getExtendedPublicKey(
   network: BitcoinNetwork,
-  cb?: Function,
+  scriptType: BitcoinScriptType,
+  cb?: (xpub: ExtendedPublicKey) => void,
 ) {
   const networkParams = network === BitcoinNetwork.Main ? 'main' : 'test';
 
-  let result = null;
+  let result = {
+    xpub: "",
+    mfp: "",
+  };
+
   try {
     result = await ethereum.request({
       method: 'wallet_invokeSnap',
@@ -53,10 +66,11 @@ export async function getExtendedPublicKey(
           method: 'btc_getPublicExtendedKey',
           params: {
             network: networkParams,
+            scriptType,
           },
         },
       ],
-    });
+    }) as ExtendedPublicKey;
   } finally {
     if (cb){
       cb(result);
@@ -64,7 +78,7 @@ export async function getExtendedPublicKey(
   }
 }
 
-export async function signPsbt(base64Psbt: string, network: BitcoinNetwork) {
+export async function signPsbt(base64Psbt: string, network: BitcoinNetwork, scriptType: BitcoinScriptType) {
   const networkParams = network === BitcoinNetwork.Main ? 'main' : 'test';
 
   try {
@@ -77,6 +91,7 @@ export async function signPsbt(base64Psbt: string, network: BitcoinNetwork) {
           params: {
             psbt: base64Psbt,
             network: networkParams,
+            scriptType,
           },
         },
       ],

--- a/packages/example/src/mobx/global.ts
+++ b/packages/example/src/mobx/global.ts
@@ -1,9 +1,10 @@
 import {types} from 'mobx-state-tree';
-import { BitcoinNetwork } from "../interface";
+import { BitcoinNetwork, BitcoinScriptType } from "../interface";
 
 const Global = types
   .model('Global', {
     network: types.enumeration(Object.values(BitcoinNetwork)),
+    scriptType: types.enumeration(Object.values(BitcoinScriptType)),
     bip44Xpub: types.string,
     connected: types.boolean,
   })

--- a/packages/example/src/mobx/store.ts
+++ b/packages/example/src/mobx/store.ts
@@ -3,12 +3,14 @@ import Global from './global';
 import Transaction from "./transaction";
 import { TransactionDetail } from "../components/TransactionCard/types";
 import { getStoredGlobalData } from "../lib/globalStorage";
+import { BitcoinScriptType } from "../interface";
 
 const storedGlobalData = getStoredGlobalData();
 
 export const storeInitialState = {
   global: {
     network: storedGlobalData.network,
+    scriptType: BitcoinScriptType.P2PKH,
     bip44Xpub: storedGlobalData.xpub[storedGlobalData.network],
     connected: !!(storedGlobalData.xpub[storedGlobalData.network]),
   },

--- a/packages/snap/README.md
+++ b/packages/snap/README.md
@@ -38,6 +38,7 @@ const result: string = await ethereum.request({
         method: 'btc_getPublicExtendedKey',
         params: {
           network: "Main" // for testnet use "Test" ,
+          scriptType: "P2PKH" // "P2SH-P2WPKH" or "P2WPKH"
         },
       },
     ],
@@ -56,6 +57,7 @@ const result: { txId:string, txHex:string } = await ethereum.request({
           params: {
             psbt: base64Psbt // base64 string for the pbst,
             network: "Main" // for testnet use "Test",
+            scriptType: "P2PKH" // "P2SH-P2WPKH" or "P2WPKH"
           },
         },
       ],

--- a/packages/snap/__tests__/bitcoin.test.ts
+++ b/packages/snap/__tests__/bitcoin.test.ts
@@ -1,8 +1,6 @@
 import { BtcTx, AccountSigner } from '../src/bitcoin'
 import { Psbt, networks } from 'bitcoinjs-lib'
 import * as bip32 from 'bip32'
-import console from 'console'
-
 
 function getAccountSigner() {
     // only for testing
@@ -12,7 +10,7 @@ function getAccountSigner() {
 }
 
 
-function getPsbtTx(pubkeyBuffer) {
+function getPsbtTx(pubkeyBuffer: Buffer) {
     const psbtTx = new Psbt({ network: networks.regtest });
     psbtTx.setVersion(2);
     psbtTx.addInput({
@@ -25,10 +23,7 @@ function getPsbtTx(pubkeyBuffer) {
         address: "mx5m68zHiGnFEoMjTdkWinmBAYsWyp9DJk",
         value: 9500
     });
-
-
     return psbtTx
-
 }
 
 

--- a/packages/snap/__tests__/rpc/index.test.ts
+++ b/packages/snap/__tests__/rpc/index.test.ts
@@ -42,7 +42,7 @@ describe('rpc', () => {
 
             walletStub.rpcStubs.snap_confirm.resolves(true);
             walletStub.rpcStubs.snap_getBip44Entropy_1.resolves({ key: testKey });
-            const result = await signPsbt(walletStub, testPsbtBase64, networks.regtest)
+            const result = await signPsbt(walletStub, testPsbtBase64, networks.regtest, ScriptType.P2PKH)
             expect(walletStub.rpcStubs.snap_getBip44Entropy_1.calledOnce).toBe(true);
             expect(result.txId).not.toBeUndefined();
             expect(result.txHex).not.toBeUndefined();
@@ -51,7 +51,7 @@ describe('rpc', () => {
         it('should reject the sign request and throw error if user reject the sign the pbst', async () => {
             try {
                 walletStub.rpcStubs.snap_confirm.resolves(false);
-                await signPsbt(walletStub, testPsbtBase64, networks.regtest)
+                await signPsbt(walletStub, testPsbtBase64, networks.regtest, ScriptType.P2PKH)
             } catch (e) {
                 expect(walletStub.rpcStubs.snap_getBip44Entropy_1.calledOnce).toBe(false);
                 expect(e).toEqual(new Error('user reject the sign request'))

--- a/packages/snap/__tests__/xpubConverter.test.ts
+++ b/packages/snap/__tests__/xpubConverter.test.ts
@@ -1,0 +1,60 @@
+import { networks } from "bitcoinjs-lib";
+import { convertXpub } from "../src/bitcoin/xpubConverter";
+import { ScriptType } from "../src/interface";
+
+// abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
+const BIP_32_EXTENDED_PUB_KEY = {
+  mainnet: {
+    P2PKH: "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj",
+    P2SH_P2WPKH: "xpub6C6nQwHaWbSrzs5tZ1q7m5R9cPK9eYpNMFesiXsYrgc1P8bvLLAet9JfHjYXKjToD8cBRswJXXbbFpXgwsswVPAZzKMa1jUp2kVkGVUaJa7",
+    P2WPKH: "xpub6CatWdiZiodmUeTDp8LT5or8nmbKNcuyvz7WyksVFkKB4RHwCD3XyuvPEbvqAQY3rAPshWcMLoP2fMFMKHPJ4ZeZXYVUhLv1VMrjPC7PW6V"
+  },
+  testnet: {
+    P2PKH: "tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba",
+    P2SH_P2WPKH: "tpubDD7tXK8KeQ3YY83yWq755fHY2JW8Ha8Q765tknUM5rSvjPcGWfUppDFMpQ1ScziKfW3ZNtZvAD7M3u7bSs7HofjTD3KP3YxPK7X6hwV8Rk2",
+    P2WPKH: "tpubDC8msFGeGuwnKG9Upg7DM2b4DaRqg3CUZa5g8v2SRQ6K4NSkxUgd7HsL2XVWbVm39yBA4LAxysQAm397zwQSQoQgewGiYZqrA9DsP4zbQ1M"
+  },
+}
+
+const SLIP_132_EXTENEDED_PUB_KEY = {
+  mainnet: {
+    P2PKH: "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj",
+    P2SH_P2WPKH: "ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP",
+    P2WPKH: "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs"
+  },
+  testnet: {
+    P2PKH: "tpubDC5FSnBiZDMmhiuCmWAYsLwgLYrrT9rAqvTySfuCCrgsWz8wxMXUS9Tb9iVMvcRbvFcAHGkMD5Kx8koh4GquNGNTfohfk7pgjhaPCdXpoba",
+    P2SH_P2WPKH: "upub5EFU65HtV5TeiSHmZZm7FUffBGy8UKeqp7vw43jYbvZPpoVsgU93oac7Wk3u6moKegAEWtGNF8DehrnHtv21XXEMYRUocHqguyjknFHYfgY",
+    P2WPKH: "vpub5Y6cjg78GGuNLsaPhmYsiw4gYX3HoQiRBiSwDaBXKUafCt9bNwWQiitDk5VZ5BVxYnQdwoTyXSs2JHRPAgjAvtbBrf8ZhDYe2jWAqvZVnsc"
+  },
+}
+
+describe('xpubConverter', () => {
+  describe('mainnet', () => {
+    it('should convert bip32 P2PKH xpub to slip132 xpub', () => {
+      expect(convertXpub(BIP_32_EXTENDED_PUB_KEY.mainnet.P2PKH, ScriptType.P2PKH, networks.bitcoin)).toBe(SLIP_132_EXTENEDED_PUB_KEY.mainnet.P2PKH)
+    })
+    
+    it('should convert bip32 P2SH-P2WPKH xpub to slip132 ypub', () => {
+      expect(convertXpub(BIP_32_EXTENDED_PUB_KEY.mainnet.P2SH_P2WPKH, ScriptType.P2SH_P2WPKH, networks.bitcoin)).toBe(SLIP_132_EXTENEDED_PUB_KEY.mainnet.P2SH_P2WPKH)
+    })
+
+    it('should convert bip32 P2WPKH xpub to zpub', () => {
+      expect(convertXpub(BIP_32_EXTENDED_PUB_KEY.mainnet.P2WPKH, ScriptType.P2WPKH, networks.bitcoin)).toBe(SLIP_132_EXTENEDED_PUB_KEY.mainnet.P2WPKH)
+    })
+  })
+
+  describe('Testnet', () => {
+    it('should convert bip32 P2PKH xpub to slip132 xpub', () => {
+      expect(convertXpub(BIP_32_EXTENDED_PUB_KEY.testnet.P2PKH, ScriptType.P2PKH, networks.regtest)).toBe(SLIP_132_EXTENEDED_PUB_KEY.testnet.P2PKH)
+    })
+    
+    it('should convert bip32 P2SH-P2WPKH xpub to slip132 upub', () => {
+      expect(convertXpub(BIP_32_EXTENDED_PUB_KEY.testnet.P2SH_P2WPKH, ScriptType.P2SH_P2WPKH, networks.regtest)).toBe(SLIP_132_EXTENEDED_PUB_KEY.testnet.P2SH_P2WPKH)
+    })
+
+    it('should convert bip32 P2WPKH xpub to vpub', () => {
+      expect(convertXpub(BIP_32_EXTENDED_PUB_KEY.testnet.P2WPKH, ScriptType.P2WPKH, networks.regtest)).toBe(SLIP_132_EXTENEDED_PUB_KEY.testnet.P2WPKH)
+    })
+  });
+})

--- a/packages/snap/index.html
+++ b/packages/snap/index.html
@@ -61,7 +61,8 @@
           params: [snapId, {
             method: 'btc_getPublicExtendedKey',
             params: {
-              network: "test"
+              network: "test",
+              scriptType: "P2PKH"
             }
           }]
         })
@@ -81,7 +82,8 @@
             method: 'btc_signPsbt',
             params: {
               psbt: "cHNidP8BAFUCAAAAAT9MXJk0OEoyuubJXTnMqxo7Hj08Wv7yHJsw9URN/9a7AQAAAAD/////ARwlAAAAAAAAGXapFLW2YqzVecKrjOg8i5S0MDzxe/OmiKwAAAAAAAEA4QIAAAAAAQGGHEltyRyXjljtT3zc4tO1/4Y1U5zibwVdAl9QxaXdCQEAAAAA/v///wI1xv9wAAAAABYAFIWiDQ/MrBorRi/oI6gcJXZ8OlKRECcAAAAAAAAZdqkUtbZirNV5wquM6DyLlLQwPPF786aIrAJHMEQCICh8bgzVpHXdYRzjQKHwro1i8zZQWb9JF0C90qy2UbN+AiA6x4zrT04ZDicTqT2xUuFywc7e1H/BYwm69N1w6W6/wAEhA2ijz+sT/T1ycTtaI1/ZfCmtv5r8BkT52aFU1akQJlJHqmchACIGA5QpeTH0HwcDirFXCpKj+/v0ttc8sOP4PwSLUJRWIJiXDP0+QYsAAAAAAAAAAAAA",
-              network: "test"
+              network: "test",
+              scriptType: "P2PKH"
             }
           }]
         })

--- a/packages/snap/index.html
+++ b/packages/snap/index.html
@@ -28,6 +28,7 @@
     <button class="getPubKey">Get extended Public Key</button>
     <button class="signPsbt">Sign Psbt</button>
     <div id="extendedPubKey" style="margin-top:5px"></div>
+    <div id="mfp" style="margin-top:5px"></div>
     <div id="txId" style="margin-top:5px"></div>
     <div id="txHex" style="margin-top:5px"></div>
   </body>
@@ -62,12 +63,14 @@
             method: 'btc_getPublicExtendedKey',
             params: {
               network: "test",
-              scriptType: "P2PKH"
+              scriptType: "P2WPKH"
             }
           }]
         })
-        const node1 = document.getElementById("extendedPubKey")
-        node1.textContent = `extended public key: ${response}`
+        const xpubNode = document.getElementById("extendedPubKey")
+        const mfpNode = document.getElementById("mfp")
+        xpubNode.textContent = `extended public key: ${response.xpub}`
+        mfpNode.textContent = `mfp: ${response.mfp}`
       } catch (err) {
         console.error(err)
         alert('Problem happened: ' + err.message || err)

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btcsnap",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "btcsnap: Metamask snap to manage your bitcoin",
   "author": "aaronisme <aarondongchen@gmail.com>",
   "homepage": "",
@@ -35,13 +35,15 @@
   "dependencies": {
     "@metamask/snaps-cli": "^0.18.0",
     "bip32": "^2.0.6",
-    "bitcoinjs-lib": "^6.0.1"
+    "bitcoinjs-lib": "^6.0.1",
+    "bs58check": "^2.1.2"
   },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
+    "@types/bs58check": "^2.1.0",
     "prettier": "^2.7.1"
   }
 }

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -36,7 +36,8 @@
     "@metamask/snaps-cli": "^0.18.0",
     "bip32": "^2.0.6",
     "bitcoinjs-lib": "^6.0.1",
-    "bs58check": "^2.1.2"
+    "bs58check": "^2.1.2",
+    "create-hash": "^1.2.0"
   },
   "publishConfig": {
     "access": "public",
@@ -44,6 +45,7 @@
   },
   "devDependencies": {
     "@types/bs58check": "^2.1.0",
+    "@types/create-hash": "^1.2.2",
     "prettier": "^2.7.1"
   }
 }

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/KeystoneHQ/btcsnap"
   },
   "source": {
-    "shasum": "mzilRjQz+7YyQdgO6Y9vbN46pJL9kw6esyO7Sf3hOoY=",
+    "shasum": "6/xOhvjGr3Poo7rGv5IFzvlazRy4+3v3R1CcwUtfa/k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -18,6 +18,7 @@
   },
   "initialPermissions": {
     "snap_confirm": {},
+    "snap_manageState": {},
     "snap_getBip32Entropy": [
       {
         "path": [

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,13 +1,13 @@
 {
-  "version": "0.4.0",
-  "description": "btcsnap: Metamask snap to manage your bitcoin",
+  "version": "0.5.0",
+  "description": "btcsnap: Metamask Snap to manage your bitcoin",
   "proposedName": "btcsnap",
   "repository": {
     "type": "git",
     "url": "https://github.com/KeystoneHQ/btcsnap"
   },
   "source": {
-    "shasum": "AjV7QBSXOwNWtTZmbdPIiI+Tp1ThrizGUX8dGKntdsA=",
+    "shasum": "mzilRjQz+7YyQdgO6Y9vbN46pJL9kw6esyO7Sf3hOoY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -18,8 +18,56 @@
   },
   "initialPermissions": {
     "snap_confirm": {},
-    "snap_getBip44Entropy_0": {},
-    "snap_getBip44Entropy_1": {}
+    "snap_getBip32Entropy": [
+      {
+        "path": [
+          "m",
+          "44'",
+          "0'"
+        ],
+        "curve": "secp256k1"
+      },
+      {
+        "path": [
+          "m",
+          "44'",
+          "1'"
+        ],
+        "curve": "secp256k1"
+      },
+      {
+        "path": [
+          "m",
+          "49'",
+          "0'"
+        ],
+        "curve": "secp256k1"
+      },
+      {
+        "path": [
+          "m",
+          "49'",
+          "1'"
+        ],
+        "curve": "secp256k1"
+      },
+      {
+        "path": [
+          "m",
+          "84'",
+          "0'"
+        ],
+        "curve": "secp256k1"
+      },
+      {
+        "path": [
+          "m",
+          "84'",
+          "1'"
+        ],
+        "curve": "secp256k1"
+      }
+    ]
   },
   "manifestVersion": "0.1"
 }

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/KeystoneHQ/btcsnap"
   },
   "source": {
-    "shasum": "6/xOhvjGr3Poo7rGv5IFzvlazRy4+3v3R1CcwUtfa/k=",
+    "shasum": "LuHze4BZZCrHM2+PbT1BvtwoQkPl5Pk/s5uKkKpc8pY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/bitcoin/crypto.ts
+++ b/packages/snap/src/bitcoin/crypto.ts
@@ -1,0 +1,7 @@
+import { default as createHash } from 'create-hash';
+
+export function sha256(buffer: Buffer): Buffer {
+  return createHash('sha256')
+    .update(buffer)
+    .digest();
+}

--- a/packages/snap/src/bitcoin/xpubConverter.ts
+++ b/packages/snap/src/bitcoin/xpubConverter.ts
@@ -1,0 +1,40 @@
+import { ScriptType, BitcoinNetwork } from "../interface";
+import { Network, networks } from 'bitcoinjs-lib';
+import { encode, decode } from "bs58check";
+
+type XpubPrefix = "xpub" | "tpub" | "ypub" | "upub" | "zpub" | "vpub";
+
+// https://github.com/satoshilabs/slips/blob/master/slip-0132.md#registered-hd-version-bytes
+const xpubPrefixes: Record<XpubPrefix, string> = {
+  'xpub': '0488b21e',
+  'tpub': '043587cf',
+  'ypub': '049d7cb2',
+  'upub': '044a5262',
+  'zpub': '04b24746',
+  'vpub': '045f1cf6',
+}
+
+const scriptTypeToXpubPrefix: Record<ScriptType, Record<BitcoinNetwork, XpubPrefix>> = {
+  [ScriptType.P2PKH]: {
+    main: 'xpub',
+    test: 'tpub'
+  },
+  [ScriptType.P2SH_P2WPKH]: {
+    main: 'ypub',
+    test: 'upub'
+  },
+  [ScriptType.P2WPKH]: {
+    main: 'zpub',
+    test: 'vpub'
+  },
+}
+
+export const convertXpub = (xpub: string, to: ScriptType, network: Network): string => {
+  const net = network === networks.bitcoin ? BitcoinNetwork.Main : BitcoinNetwork.Test;
+  const xpubPrefix = scriptTypeToXpubPrefix[to][net];
+
+  let data = decode(xpub);
+  data = data.slice(4);
+  data = Buffer.concat([Buffer.from(xpubPrefixes[xpubPrefix], "hex"), data]);
+  return encode(data);
+}

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -1,5 +1,5 @@
 import { getNetwork } from './bitcoin';
-import {Wallet, ScriptType, MetamaskBTCRpcRequest} from './interface'
+import {Wallet, MetamaskBTCRpcRequest} from './interface'
 import { getExtendedPublicKey, signPsbt} from './rpc'
 
 declare let wallet: Wallet;
@@ -12,10 +12,10 @@ type rpcReqeust = {
 export const onRpcRequest = async({origin, request}:rpcReqeust) => {
   switch (request.method) {
     case 'btc_getPublicExtendedKey':
-      return getExtendedPublicKey(wallet, ScriptType.P2PKH, getNetwork(request.params.network))
+      return getExtendedPublicKey(wallet, request.params.scriptType, getNetwork(request.params.network))
     case 'btc_signPsbt':
       const psbt = request.params.psbt;
-      return signPsbt(wallet, psbt, getNetwork(request.params.network))
+      return signPsbt(wallet, psbt, getNetwork(request.params.network), request.params.scriptType)
     default:
       throw new Error('Method not found.');
   }

--- a/packages/snap/src/interface.ts
+++ b/packages/snap/src/interface.ts
@@ -39,6 +39,9 @@ export enum BitcoinNetwork {
   Test = "test",
 }
 
+export interface PersistedData {
+  mfp?: string
+}
 
 export interface SLIP10Node {
   /**

--- a/packages/snap/src/interface.ts
+++ b/packages/snap/src/interface.ts
@@ -1,7 +1,8 @@
 export interface GetPublicExtendedKeyRequest{
     method: "btc_getPublicExtendedKey";
     params: {
-      network: BitcoinNetwork
+      network: BitcoinNetwork,
+      scriptType: ScriptType
     }
 }
 
@@ -9,7 +10,8 @@ export interface SignPsbt{
   method: "btc_signPsbt";
   params: {
     psbt: string,
-    network: BitcoinNetwork
+    network: BitcoinNetwork,
+    scriptType: ScriptType
   }
 }
 
@@ -22,12 +24,14 @@ export type BTCMethodCallback = (
 
 export interface Wallet {
   registerRpcMessageHandler: (fn: BTCMethodCallback) => unknown;
-  request(options: {method: string; params?: unknown[]}): Promise<unknown>;
+  request(options: {method: string; params?: unknown[] | Record<string, any>}): Promise<unknown>;
 }
 
 
 export enum ScriptType {
     P2PKH = "P2PKH",
+    P2SH_P2WPKH = "P2SH-P2WPKH",
+    P2WPKH = "P2WPKH"
 }
 
 export enum BitcoinNetwork {
@@ -36,48 +40,39 @@ export enum BitcoinNetwork {
 }
 
 
-export interface BIP44CoinTypeNode {
+export interface SLIP10Node {
   /**
-   * The BIP-44 `coin_type` value of this node.
+   * The 0-indexed path depth of this node.
    */
-  readonly coin_type: number;
+  readonly depth: number;
 
   /**
-   * The 0-indexed BIP-44 path depth of this node.
-   *
-   * Since this is a `coin_type` node, it will be the number `2`.
+   * The fingerprint of the parent key, or 0 if this is a master node.
    */
-  readonly depth: 2;
+  readonly parentFingerprint: number;
 
   /**
-   * The hexadecimal-encoded string representation of the private key for this node.
+   * The index of the node, or 0 if this is a master node.
+   */
+  readonly index: number;
+
+  /**
+   * The private key of this node.
    */
   readonly privateKey: string;
 
   /**
-   * The hexadecimal-encoded string representation of the public key for this node.
+   * The public key of this node.
    */
   readonly publicKey: string;
 
   /**
-   * The hexadecimal-encoded string representation of the chain code for this node.
+   * The chain code of this node.
    */
   readonly chainCode: string;
 
   /**
-   * A human-readable representation of the BIP-44 HD tree path of this node.
-   *
-   * Since this is a `coin_type` node, it will be of the form:
-   *
-   * `m / 44' / coin_type'`
-   *
-   * Recall that a complete BIP-44 HD tree path consists of the following nodes:
-   *
-   * `m / 44' / coin_type' / account' / change / address_index`
-   *
-   * With the following depths:
-   *
-   * `0 / 1 / 2 / 3 / 4 / 5`
+   * The name of the curve used by the node.
    */
-  readonly path: string;
+  readonly curve: 'ed25519' | 'secp256k1';
 }

--- a/packages/snap/src/rpc/getExtendedPublicKey.ts
+++ b/packages/snap/src/rpc/getExtendedPublicKey.ts
@@ -11,6 +11,8 @@ const pathMap: Record<ScriptType, string[]> = {
     [ScriptType.P2WPKH]: ['m', "84'", "0'"]
 }
 
+const CRYPTO_CURVE = "secp256k1";
+
 export async function extractAccountPrivateKey(wallet: Wallet, network: Network, scriptType: ScriptType): Promise<BIP32Interface> {
     const path = pathMap[scriptType]
     if (network != networks.bitcoin) {
@@ -21,7 +23,7 @@ export async function extractAccountPrivateKey(wallet: Wallet, network: Network,
         method: "snap_getBip32Entropy",
         params: {
             path,
-            curve: "secp256k1"
+            curve: CRYPTO_CURVE
         },
     }) as SLIP10Node
 

--- a/packages/snap/src/rpc/getExtendedPublicKey.ts
+++ b/packages/snap/src/rpc/getExtendedPublicKey.ts
@@ -1,33 +1,38 @@
 import * as bip32 from 'bip32';
-import { Network, networks } from 'bitcoinjs-lib';
 import { BIP32Interface } from 'bip32';
-import { Wallet, ScriptType, BIP44CoinTypeNode } from "../interface";
+import { Network, networks } from 'bitcoinjs-lib';
+import { ScriptType, SLIP10Node, Wallet } from "../interface";
+import { convertXpub } from "../bitcoin/xpubConverter";
 
+const pathMap: Record<ScriptType, string[]> = {
+    [ScriptType.P2PKH]: ['m', "44'", "0'"],
+    [ScriptType.P2SH_P2WPKH]: ['m', "49'", "0'"],
+    [ScriptType.P2WPKH]: ['m', "84'", "0'"]
+}
 
-const HIGHEST_BIT = 0x80000000;
-
-
-
-export async function extractAccoutPrivateKey(wallet: Wallet, network: Network): Promise<BIP32Interface> {
-
-    let coinType: number = 0;
+export async function extractAccountPrivateKey(wallet: Wallet, network: Network, scriptType: ScriptType): Promise<BIP32Interface> {
+    const path = pathMap[scriptType]
     if (network != networks.bitcoin) {
-        coinType = 1
+        path[path.length - 1] = "1'";
     }
 
-    const methodName = `snap_getBip44Entropy_${coinType}`
-    const bitcoin44node = await wallet.request({
-        method: methodName
-    }) as BIP44CoinTypeNode
-    const privateKeyBuffer = Buffer.from(bitcoin44node.privateKey, "hex")
-    const chainCodeBuffer = Buffer.from(bitcoin44node.chainCode, "hex")
-    let node: BIP32Interface = bip32.fromPrivateKey(privateKeyBuffer, chainCodeBuffer, network)
+    const slip10Node = await wallet.request({
+        method: "snap_getBip32Entropy",
+        params: {
+            path,
+            curve: "secp256k1"
+        },
+    }) as SLIP10Node
+
+    const privateKeyBuffer = Buffer.from(slip10Node.privateKey, "hex")
+    const chainCodeBuffer = Buffer.from(slip10Node.chainCode, "hex")
+    const node: BIP32Interface = bip32.fromPrivateKey(privateKeyBuffer, chainCodeBuffer, network)
     //@ts-ignore 
     // ignore checking since no function to set depth for node
-    node.__DEPTH = 2;
+    node.__DEPTH = slip10Node.depth;
     //@ts-ignore
     // ignore checking since no function to set index for node
-    node.__INDEX = HIGHEST_BIT + 0;
+    node.__INDEX = slip10Node.index;
     return node.deriveHardened(0);
 }
 
@@ -35,6 +40,8 @@ export async function extractAccoutPrivateKey(wallet: Wallet, network: Network):
 export async function getExtendedPublicKey(wallet: Wallet, scriptType: ScriptType, network: Network): Promise<string> {
     switch (scriptType) {
         case ScriptType.P2PKH:
+        case ScriptType.P2WPKH:
+        case ScriptType.P2SH_P2WPKH:
             const result = await wallet.request({
                 method: 'snap_confirm',
                 params: [
@@ -46,9 +53,9 @@ export async function getExtendedPublicKey(wallet: Wallet, scriptType: ScriptTyp
             });
 
             if(result) {
-                let accountNode = await extractAccoutPrivateKey(wallet, network)
-                let accountPublicKey = accountNode.neutered();
-                return accountPublicKey.toBase58();
+                const accountNode = await extractAccountPrivateKey(wallet, network, scriptType)
+                const accountPublicKey = accountNode.neutered();
+                return convertXpub(accountPublicKey.toBase58(), scriptType, network);
             } else {
                 throw new Error('User reject to access the key')
             }

--- a/packages/snap/src/rpc/signPSBT.ts
+++ b/packages/snap/src/rpc/signPSBT.ts
@@ -1,10 +1,10 @@
-import { Wallet } from "../interface";
+import { ScriptType, Wallet } from "../interface";
 import { Network } from "bitcoinjs-lib"; 
-import { extractAccoutPrivateKey } from './getExtendedPublicKey'
+import { extractAccountPrivateKey } from './getExtendedPublicKey'
 import { BtcTx, AccountSigner } from "../bitcoin/index"
 
 
-export async function signPsbt(wallet: Wallet, psbt: string, network: Network): Promise<{ txId: string, txHex: string }> {
+export async function signPsbt(wallet: Wallet, psbt: string, network: Network, scriptType: ScriptType): Promise<{ txId: string, txHex: string }> {
   const btcTx = new BtcTx(psbt)
   const result = await wallet.request({
     method: 'snap_confirm',
@@ -18,7 +18,7 @@ export async function signPsbt(wallet: Wallet, psbt: string, network: Network): 
   });
 
   if (result) {
-    const accountPrivateKey = await extractAccoutPrivateKey(wallet, network)
+    const accountPrivateKey = await extractAccountPrivateKey(wallet, network, scriptType)
     const signer = new AccountSigner(accountPrivateKey)
     btcTx.validateTx(signer)
     return btcTx.signTx(signer)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,6 +3825,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/bs58check@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/bs58check/-/bs58check-2.1.0.tgz#7d25a8b88fe7a9e315d2647335ee3c43c8fdb0c0"
+  integrity sha512-OxsysnJQh82vy9DRbOcw9m2j/WiyqZLn0YBhKxdQ+aCwoHj+tWzyCgpwAkr79IfDXZKxc6h7k89T9pwS78CqTQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/chrome@^0.0.136":
   version "0.0.136"
   resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.136.tgz#7c011b9f997b0156f25a140188a0c5689d3f368f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3855,6 +3855,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/create-hash@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@types/create-hash/-/create-hash-1.2.2.tgz#e87247083df8478f6b83655592bde0d709028235"
+  integrity sha512-Fg8/kfMJObbETFU/Tn+Y0jieYewryLrbKwLCEIwPyklZZVY2qB+64KFjhplGSw+cseZosfFXctXO+PyIYD8iZQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/deep-freeze-strict@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/deep-freeze-strict/-/deep-freeze-strict-1.1.0.tgz#447a6a2576191344aa42310131dd3df5c41492c4"


### PR DESCRIPTION
### Changes
- Replace `snap_getBip44Entropy_*` with `snap_getBip32Entropy` in `btcsnap`
- Get extended public key `P2PKH`, `P2SH-P2WPKH` and `P2WPKH` from `btcsnap`

### Links
- MM PR: https://github.com/MetaMask/snaps-skunkworks/pull/683
- MM docs: https://github.com/MetaMask/metamask-docs/pull/539